### PR TITLE
電話番号OTP認証APIの実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "otplogin",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,89 @@
+const http = require('http');
+
+const otpStore = new Map(); // phone -> { code, expiresAt }
+const verifiedPhones = new Set();
+const OTP_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+function generateCode() {
+  return String(Math.floor(100000 + Math.random() * 900000));
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => { data += chunk; });
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch (e) {
+        reject(e);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+async function handler(req, res) {
+  if (req.method === 'POST' && req.url === '/api/send-otp') {
+    const { phone } = await readBody(req);
+    const code = generateCode();
+    otpStore.set(phone, { code, expiresAt: Date.now() + OTP_TTL_MS });
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'sent' }));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/api/verify-otp') {
+    const { phone, code } = await readBody(req);
+    const entry = otpStore.get(phone);
+    if (!entry || entry.expiresAt < Date.now()) {
+      otpStore.delete(phone);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'expired_or_not_found' }));
+      return;
+    }
+    if (entry.code !== code) {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'invalid' }));
+      return;
+    }
+    otpStore.delete(phone);
+    verifiedPhones.add(phone);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'verified' }));
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/api/register') {
+    const { phone } = await readBody(req);
+    const status = verifiedPhones.has(phone) ? 'registered' : 'not_verified';
+    if (status === 'registered') {
+      verifiedPhones.delete(phone);
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status }));
+    return;
+  }
+
+  res.writeHead(404, { 'Content-Type': 'text/plain' });
+  res.end('Not Found');
+}
+
+function createServer() {
+  return http.createServer((req, res) => {
+    handler(req, res).catch(err => {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'internal_error' }));
+    });
+  });
+}
+
+if (require.main === module) {
+  const server = createServer();
+  const port = process.env.PORT || 3000;
+  server.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+}
+
+module.exports = { createServer, otpStore, verifiedPhones, OTP_TTL_MS };

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,64 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { createServer, otpStore, verifiedPhones } = require('../server');
+
+const phone = '+819012345678';
+
+function startServer() {
+  return new Promise(resolve => {
+    const server = createServer();
+    const listener = server.listen(0, () => {
+      const { port } = listener.address();
+      resolve({ server, port });
+    });
+  });
+}
+
+async function post(port, path, body) {
+  const res = await fetch(`http://localhost:${port}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  return res.json();
+}
+
+test('OTP flow end-to-end', async (t) => {
+  const { server, port } = await startServer();
+
+  // send OTP
+  let data = await post(port, '/api/send-otp', { phone });
+  assert.deepStrictEqual(data, { status: 'sent' });
+  let entry = otpStore.get(phone);
+  assert.ok(entry);
+
+  // wrong code
+  data = await post(port, '/api/verify-otp', { phone, code: '000000' });
+  assert.deepStrictEqual(data, { status: 'invalid' });
+
+  // expired code
+  entry.expiresAt = Date.now() - 1000;
+  data = await post(port, '/api/verify-otp', { phone, code: entry.code });
+  assert.deepStrictEqual(data, { status: 'expired_or_not_found' });
+
+  // resend OTP
+  data = await post(port, '/api/send-otp', { phone });
+  assert.deepStrictEqual(data, { status: 'sent' });
+  entry = otpStore.get(phone);
+
+  // correct code
+  data = await post(port, '/api/verify-otp', { phone, code: entry.code });
+  assert.deepStrictEqual(data, { status: 'verified' });
+  assert.ok(verifiedPhones.has(phone));
+
+  // register without verification
+  data = await post(port, '/api/register', { phone: '+811234567890', username: 'x', password: 'y' });
+  assert.deepStrictEqual(data, { status: 'not_verified' });
+
+  // register after verification
+  data = await post(port, '/api/register', { phone, username: 'taro', password: 'pass' });
+  assert.deepStrictEqual(data, { status: 'registered' });
+  assert.ok(!verifiedPhones.has(phone));
+
+  server.close();
+});


### PR DESCRIPTION
## 概要
- OTP送信・検証・登録のAPIを実装
- メモリストアを用いて期限付きOTP管理と登録前の認証チェックを実装
- OTPフローのエンドツーエンドテストを追加

## テスト
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae4fc942188321bae985ed684411ac